### PR TITLE
Add PKGBUILD for toxbot-git

### DIFF
--- a/unverified/other/toxbot-git/PKGBUILD
+++ b/unverified/other/toxbot-git/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Kevin MacMartin <prurigro at gmail dot com>
+
+_pkgname=toxbot
+pkgname=$_pkgname-git
+pkgver=r32.acfabb8
+pkgrel=1
+pkgdesc='Remotely controlled Tox bot whose purpose is to auto-invite friends to Tox groupchats'
+arch=('i686' 'x86_64' 'arm' 'armv6h' 'armv7h')
+url='https://github.com/JFreegman/ToxBot'
+license=('GPL3')
+depends=('tox-git')
+makedepends=('git')
+conflicts=("$_pkgname")
+provides=("$_pkgname")
+
+source=("$pkgname::git+$url")
+sha512sums=('SKIP')
+
+pkgver() {
+  cd $pkgname
+  printf 'r%s.%s' "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd $pkgname
+  make
+}
+
+package() {
+  cd $pkgname
+  install -Dm755 $_pkgname "$pkgdir/usr/bin/$_pkgname"
+  install -Dm644 README.md "$pkgdir/usr/share/doc/$_pkgname/README.md"
+  install -Dm644 commands.txt "$pkgdir/usr/share/doc/$_pkgname/commands.txt"
+}

--- a/unverified/other/toxbot-git/PKGBUILD
+++ b/unverified/other/toxbot-git/PKGBUILD
@@ -1,4 +1,5 @@
-# Maintainer: Kevin MacMartin <prurigro at gmail dot com>
+# Maintainer: ?
+# Contributor: Kevin MacMartin <prurigro at gmail dot com>
 
 _pkgname=toxbot
 pkgname=$_pkgname-git


### PR DESCRIPTION
This adds the PKGBUILD for https://aur.archlinux.org/packages/toxbot-git/
